### PR TITLE
Update bookable.gemspec

### DIFF
--- a/bookable.gemspec
+++ b/bookable.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
  
-  spec.add_dependency 'jbuilder', '~> 1.2'
+  spec.add_dependency 'jbuilder'
   spec.add_dependency 'rails_12factor'
 
 end


### PR DESCRIPTION
Removed dependency to version.

with the change in the rails newer version, the strict dependency of 'jbuilder' is causing issues with installation of the gem.